### PR TITLE
No function sanitizing in GO JSON output

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ func main() {
 		fmt.Println(err)
 		return
 	}
-	// TODO: call python fastTest model with jsonData string.
 	err = pythonrunner.ExecPythonModel("./python_helper/fastModelCompare.py", "./fast-fb-model.bin", jsonData)
 	if err != nil {
 		println("ExecPythonModel; Error;", err.Error())

--- a/python_helper/compareHelper.py
+++ b/python_helper/compareHelper.py
@@ -1,6 +1,17 @@
 # Provides helper functions for doing comparisons using the provided model.
 from colors import blue, green, red, yellow
 from gensim.models import FastText
+import re
+
+
+def sanitize_name(name: str) -> str:
+    """
+    Takes a string and sanitizes it to conform to camelCase naming convention
+    and then make everything lowercase.
+
+    Returns sanitized string.
+    """
+    return re.sub("[^a-zA-Z0-9 ]+", "", name).lower()
 
 
 def compare_package_function_list_distance(package_name: str, function_list: list[str], model: FastText):
@@ -19,7 +30,8 @@ def compare_package_function_list_distance(package_name: str, function_list: lis
     for function in function_list:
         print(
             yellow(f"\tFunction '{function}':"),
-            green(model.wv.distance(package_name.lower(), function.lower())),
+            green(model.wv.distance(sanitize_name(
+                package_name), sanitize_name(function))),
         )
 
 
@@ -50,7 +62,7 @@ def find_best_matching_package(function_name: str, package_list: list[str], mode
     distances: dict[float, str] = {}
     for package_name in package_list:
         dist: float = model.wv.distance(
-            package_name.lower(), function_name.lower())
+            sanitize_name(package_name), sanitize_name(function_name))
         distances[dist] = package_name
 
     dist_list: list[float] = list(distances.keys())
@@ -68,7 +80,7 @@ def list_most_similar(function_list: list[str], model: FastText):
     """
     for function in function_list:
         print(blue(f'Results for words found similar to "{function}"'))
-        print(green(model.wv.most_similar(function.lower())))
+        print(green(model.wv.most_similar(sanitize_name(function))))
 
 
 def find_non_matching_function(function_list: list[str], model: FastText):
@@ -79,5 +91,5 @@ def find_non_matching_function(function_list: list[str], model: FastText):
     Prints the name of that function.
     """
     print(blue("Results for word that least fits in given word list"))
-    function_list = [function.lower() for function in function_list]
+    function_list = [sanitize_name(function) for function in function_list]
     print(red(model.wv.doesnt_match(function_list)))

--- a/python_helper/compareHelper.py
+++ b/python_helper/compareHelper.py
@@ -19,7 +19,7 @@ def compare_package_function_list_distance(package_name: str, function_list: lis
     for function in function_list:
         print(
             yellow(f"\tFunction '{function}':"),
-            green(model.wv.distance(package_name, function)),
+            green(model.wv.distance(package_name.lower(), function.lower())),
         )
 
 
@@ -49,7 +49,8 @@ def find_best_matching_package(function_name: str, package_list: list[str], mode
     """
     distances: dict[float, str] = {}
     for package_name in package_list:
-        dist: float = model.wv.distance(package_name, function_name)
+        dist: float = model.wv.distance(
+            package_name.lower(), function_name.lower())
         distances[dist] = package_name
 
     dist_list: list[float] = list(distances.keys())
@@ -67,7 +68,7 @@ def list_most_similar(function_list: list[str], model: FastText):
     """
     for function in function_list:
         print(blue(f'Results for words found similar to "{function}"'))
-        print(green(model.wv.most_similar(function)))
+        print(green(model.wv.most_similar(function.lower())))
 
 
 def find_non_matching_function(function_list: list[str], model: FastText):
@@ -78,4 +79,5 @@ def find_non_matching_function(function_list: list[str], model: FastText):
     Prints the name of that function.
     """
     print(blue("Results for word that least fits in given word list"))
+    function_list = [function.lower() for function in function_list]
     print(red(model.wv.doesnt_match(function_list)))

--- a/python_helper/fastModelCompare.py
+++ b/python_helper/fastModelCompare.py
@@ -2,9 +2,9 @@
 import argparse
 import json
 
-from colors import blue, green, red, yellow
+from colors import blue
 from compareHelper import (
-    compare_package_function_list_distance, find_non_matching_function, list_best_matching_package)
+    compare_package_function_list_distance, list_best_matching_package)
 from gensim.models.fasttext import load_facebook_model
 
 

--- a/python_helper/fastModelCompare.py
+++ b/python_helper/fastModelCompare.py
@@ -3,8 +3,8 @@ import argparse
 import json
 
 from colors import blue, green, red, yellow
-from compareHelper import (compare_package_function_list_distance,
-                           find_best_matching_package, list_best_matching_package)
+from compareHelper import (
+    compare_package_function_list_distance, find_non_matching_function, list_best_matching_package)
 from gensim.models.fasttext import load_facebook_model
 
 
@@ -68,7 +68,7 @@ def main():
 
         # test
         compare_package_function_list_distance(
-            "routes", ["getuser", "execpythonmodel"], model)
+            "pythonrunner", ["getuser", "ExecPythonModel"], model)
 
         return
 

--- a/src/toolParser/codeParser.go
+++ b/src/toolParser/codeParser.go
@@ -18,8 +18,8 @@ func parseCode(newPackage *projectPackage, node *ast.File) {
 	ast.Inspect(node, func(n ast.Node) bool {
 		switch x := n.(type) {
 		case *ast.FuncDecl:
-			funcName := sanitizeName(x.Name.Name)
-			if strings.HasPrefix(funcName, "test") {
+			funcName := x.Name.Name
+			if strings.HasPrefix(strings.ToLower(funcName), "test") {
 				// early return if function name starts with test,
 				// we dont want to ignore all test functions.
 				return true

--- a/src/toolParser/dataHandler.go
+++ b/src/toolParser/dataHandler.go
@@ -6,8 +6,6 @@ package toolParser
 import (
 	"encoding/json"
 	"go/ast"
-	"regexp"
-	"strings"
 )
 
 type projectPackage struct {
@@ -16,14 +14,8 @@ type projectPackage struct {
 
 var packages = make(map[string]*projectPackage)
 
-func sanitizeName(name string) string {
-	name = strings.ToLower(name)
-	name = regexp.MustCompile(`[^a-zA-Z0-9 ]+`).ReplaceAllString(name, "")
-	return name
-}
-
 func getPackageName(node *ast.File) string {
-	return sanitizeName(node.Name.Name)
+	return node.Name.Name
 }
 
 func getMapPackage(key string) *projectPackage {

--- a/src/toolParser/directoryParser.go
+++ b/src/toolParser/directoryParser.go
@@ -33,7 +33,7 @@ func ParseDir(dir string) error {
 		node, err := getGoFileNode(path)
 		if node != nil {
 			packageName := getPackageName(node)
-			if strings.HasPrefix(packageName, "test") {
+			if strings.HasPrefix(strings.ToLower(packageName), "test") {
 				// early return and skip package if it starts with `test`
 				// we want to ignore all test packages.
 				return err


### PR DESCRIPTION
Now leaves formatting for function and package names in output JSON. And python script now instead runs `lower()` on names before comparisons are made in the model. 

Allows us to keep the formatting of the names when providing the user output.